### PR TITLE
M1 gives an error when deployed new version - Observer already exist. 

### DIFF
--- a/app/code/local/Anyday/Payment/etc/config.xml
+++ b/app/code/local/Anyday/Payment/etc/config.xml
@@ -34,6 +34,7 @@
             <core_block_abstract_to_html_after>
                 <observers>
                     <adpayment>
+                        <type>singleton</type>
                         <class>adpayment/observer</class>
                         <method>addPriceTag</method>
                     </adpayment>


### PR DESCRIPTION
Adding a singleton type to observer configuration to avoid the following error.

<img width="1294" alt="Screenshot 2021-10-25 at 3 34 27 PM" src="https://user-images.githubusercontent.com/5526195/138662964-63382a09-9115-4a85-b253-880a30db6ab6.png">
